### PR TITLE
 	modified:   adsenrich/data.py

### DIFF
--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -22,4 +22,4 @@ IOP_BIBSTEMS = ['ApJ..', 'JCAP.', 'EJPh.', 'RAA..', 'PhyM.', 'JPhD.', 'AJ...', '
 
 OUP_BIBSTEMS = ['MNRAS', 'PASJ.', 'PTEP.', 'GeoJI']
 
-AIP_BIBSTEMS = ['AIPA.', 'AIPC.', 'ApPhL', 'APL..', 'APLM.', 'APLP.', 'AVSQS', 'AmJPh', 'ApPRv', 'Chaos', 'JAP..', 'JChPh', 'JMP..', 'JPCRD', 'LTP..', 'PhFl.', 'PhPl.', 'PhTea', 'RScI']
+AIP_BIBSTEMS = ['AIPA.', 'AIPC.', 'ApPhL', 'APL..', 'APLM.', 'APLP.', 'AVSQS', 'AmJPh', 'ApPRv', 'Chaos', 'JAP..', 'JChPh', 'JMP..', 'JPCRD', 'LTP..', 'PhFl.', 'PhPl.', 'PhTea', 'RScI.']


### PR DESCRIPTION
Fix to publisher-specific bibstem lists in data.py: 'RScI' -> 'RScI.' (trailing dot required)