### PR TITLE
fix: better handling of volume ranges 

### DIFF
--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -53,6 +53,9 @@ class BibcodeGenerator(object):
     def _get_volume(self, record):
         try:
             volume = record['publication']['volumeNum']
+            if "-" in volume:
+                vol_list = volume.strip().split("-")
+                volume = vol_list[0]
         except Exception as err:
             volume = '.'
         return volume

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "adsenrich"
-version = "0.0.1"
+version = "1.0.0"
 description = "ADS Enrichment Pipeline library"
 authors = [{ name = "Matthew Templeton", email = "matthew.templeton@cfa.harvard.edu"}]
 license = { text = "MIT" }


### PR DESCRIPTION
Some publishers will create a "volume" that covers a range of volumes, resulting in papers with, for example: `{"volume": "250-252"}`.  This bugfix will check the volume for a hyphen character, and if found, split on it and take the 0th element of the resulting list as the "volume" **for the bibcode only**.  The original volume string from the parsed document is retained for the publication string.