### PR TITLE
Fix t pages.20231207

### DIFF
--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -41,13 +41,20 @@ class BibcodeGenerator(object):
 
     def _get_author_init(self, record):
         author_init = "."
+        special_char = {'&ETH;': 'E',
+                        '&eth;': 'e',
+                        '&THORN;': 'TH',
+                        '&thorn;': 'th'}
         try:
             author_init = record.get("authors", [])[0]["name"]["surname"]
             first_auth = record.get("authors", [])[0]
             if first_auth:
-                author_init = first_auth.get("name", {}).get("surname", None)
-                author_init = author_init.strip()[0]
-                author_init = u2asc(author_init).upper()
+                author_last = first_auth.get("name", {}).get("surname", None)
+                author_last = author_last.strip()
+                author_last = u2asc(author_last)
+                for k, v in special_char.items():
+                    author_last = author_last.replace(k, v)
+                author_init = author_last[0].upper()
         except:
             pass
         return author_init

--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -116,6 +116,9 @@ class BibcodeGenerator(object):
         elif "E" in page:
             page = page.replace("E", "")
             is_letter = "E"
+        elif "T" in page or "t" in page:
+            page = page.replace("T", "").replace("t", ".")
+            is_letter = "T"
         return (page, is_letter)
 
     def _get_normal_pagenum(self, record):

--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -132,6 +132,7 @@ IOP_BIBSTEMS = [
     "ECSSP",
     "ECSAd",
     "ECSIn",
+    "MatFu",
 ]
 
 OUP_BIBSTEMS = ["MNRAS", "PASJ.", "PTEP.", "GeoJI"]

--- a/adsenrich/utils.py
+++ b/adsenrich/utils.py
@@ -19,6 +19,7 @@ def u2asc(input):
     """
 
     # TODO If used on anything but author names, add special handling for math symbols and other special chars
+    output = None
     if sys.version_info < (3,):
         test_type = unicode
     else:


### PR DESCRIPTION
Several minor changes:
- Adds MatFu (Materials Futures) to IOP
- Detects "T" in pageid, moves to issue_letter
- Bugfix so that utils.u2asc will not raise an exception if `output` is undefined.
- Special characters in author initial handling: Norse/Icelandic `&THORN;` and `&ETH;`

Resulted in nearly perfect parsing of IOP deliveries from 2023-10-01+ in test environment