### PR TITLE
Adding issn lookup via classic files in place of API call

### DIFF
--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -233,6 +233,11 @@ class BibcodeGenerator(object):
                     # ApJ/L are IOP journals
                     bibstem = "ApJ.."
                     issue = "L"
+                elif bibstem == "JaJAP":
+                    # JaJAP/JJAPS are IOP journals
+                    issue = self._get_issue(record)
+                    if "S" in issue:
+                        bibstem == "JJAPS"
                 if is_letter:
                     if not issue:
                         issue = is_letter

--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -177,6 +177,7 @@ class BibcodeGenerator(object):
                         issn = str(issn)
                         if len(issn) == 8:
                             issn = issn[0:4] + "-" + issn[4:]
+                        bibstem = ISSN_DICT.get(issn, None)
                         if not bibstem:
                             bibstem = issn2info(
                                 token=self.api_token,

--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -237,7 +237,7 @@ class BibcodeGenerator(object):
                     # JaJAP/JJAPS are IOP journals
                     issue = self._get_issue(record)
                     if "S" in issue:
-                        bibstem == "JJAPS"
+                        bibstem = "JJAPS"
                 if is_letter:
                     if not issue:
                         issue = is_letter

--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -2,7 +2,7 @@ import os
 
 issnfile = "/proj/ads/abstracts/config/journalsdb/PIPELINE/data/issn_identifiers"
 ISSN_DICT = {}
-if os.path.exists(infile):
+if os.path.exists(issnfile):
     with open(issnfile, "r") as fi:
         for l in fi.readlines():
             try:

--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -1,3 +1,16 @@
+import os
+
+issnfile = "/proj/ads/abstracts/config/journalsdb/PIPELINE/data/issn_identifiers"
+ISSN_DICT = {}
+if os.path.exists(infile):
+    with open(issnfile, "r") as fi:
+        for l in fi.readlines():
+            try:
+                (bibstem, id_type, id_value) = l.rstrip().split("\t")
+                ISSN_DICT[id_value] = bibstem
+            except Exception as err:
+                pass
+
 APS_BIBSTEMS = [
     "PhRvL",
     "PhRvX",

--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -542,4 +542,7 @@ REFSOURCE_DICT = {
     "egu": "egu.xml",
     "nlm": "nlm.xml",
     "copernicus": "copernicus.xml",
+    "wiley": "wiley.xml",
+    "mdpi": "mdpi.xml",
+    "edp": "edp.xml",
 }

--- a/adsenrich/utils.py
+++ b/adsenrich/utils.py
@@ -3,6 +3,7 @@ import sys
 
 import requests
 import unidecode
+import time
 
 
 class UnicodeDecodeError(Exception):
@@ -51,12 +52,18 @@ def issn2info(token=None, url=None, issn=None, return_info="bibstem"):
         url_base = url + "/journals/issn/"
         request_url = url_base + issn
         token_dict = {"Authorization": "Bearer %s" % token}
-        try:
-            req = requests.get(request_url, headers=token_dict)
-        except Exception as err:
-            pass
-        else:
-            if req.status_code == 200:
-                result = req.json()
-                return result.get("issn", {}).get(return_info, None)
+        icount = 0
+        maxcount = 10
+        while icount < maxcount:
+            try:
+                req = requests.get(request_url, headers=token_dict)
+            except Exception as err:
+                icount += 1
+            else:
+                if req.status_code == 200:
+                    result = req.json()
+                    return result.get("issn", {}).get(return_info, None)
+                else:
+                    time.sleep(10)
+                    icount += 1
     return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ packages = [
 
 dependencies = [
     'unidecode==0.4.21',
-    'adsputils @ git+https://github.com/adsabs/ADSPipelineUtils.git@v1.4.3',
+    'adsputils @ git+https://github.com/adsabs/ADSPipelineUtils.git@v1.5.2',
 ]
 
 


### PR DESCRIPTION
Previously, bibstem lookup for bibcode creation was making an API call every time a record was parsed.  Now, we will use the ISSN bibstem lookup file in abstracts/config/journalsdb, if it exists.