### PR TITLE
Bugfix for getting bibstem from issn

### DIFF
--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -178,13 +178,15 @@ class BibcodeGenerator(object):
                         if len(issn) == 8:
                             issn = issn[0:4] + "-" + issn[4:]
                         bibstem = ISSN_DICT.get(issn, None)
-                        if not bibstem:
-                            bibstem = issn2info(
-                                token=self.api_token,
-                                url=self.api_url,
-                                issn=issn,
-                                return_info="bibstem",
-                            )
+                        if bibstem:
+                            break
+                if not bibstem:
+                    bibstem = issn2info(
+                    token=self.api_token,
+                    url=self.api_url,
+                    issn=issn,
+                    return_info="bibstem",
+                )
         if bibstem:
             return bibstem
         else:


### PR DESCRIPTION
 	modified:   adsenrich/bibcodes.py

xml file may have multiple issns (print, electronic).  Previously, if the last issn in the list wasn't mapped to a bibstem, it would assign bibstem=None.  The code will now break out of the string-testing loop if it finds a match.