### PR TITLE
Csg bibc fixes.20250211

### DIFF
--- a/adsenrich/bibcodes.py
+++ b/adsenrich/bibcodes.py
@@ -126,6 +126,12 @@ class BibcodeGenerator(object):
             fpage = pagination.get("firstPage", None)
             epage = pagination.get("electronicID", None)
             rpage = pagination.get("pageRange", None)
+            if fpage == "NP":
+                fpage = ""
+            if epage == "NP":
+                epage = ""
+            if rpage == "NP-NP":
+                rpage = ""
             if fpage:
                 page = fpage
             elif epage:

--- a/adsenrich/data.py
+++ b/adsenrich/data.py
@@ -11,6 +11,17 @@ if os.path.exists(issnfile):
             except Exception as err:
                 pass
 
+isbnfile = "/proj/ads/abstracts/config/journalsdb/PIPELINE/data/isbn_identifiers"
+ISBN_DICT = {}
+if os.path.exists(isbnfile):
+    with open(isbnfile, "r") as fi:
+        for l in fi.readlines():
+            try:
+                (bibstem, id_type, id_value) = l.rstrip().split("\t")
+                ISBN_DICT[id_value] = bibstem
+            except Exception as err:
+                pass
+
 APS_BIBSTEMS = [
     "PhRvL",
     "PhRvX",
@@ -1338,4 +1349,5 @@ REFSOURCE_DICT = {
     "edp": "edp.xml",
     "elsevier": "elsevier.xml",
     "spie": "spie.xml",
+    "ieee": "ieee.xml",
 }

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -125,6 +125,7 @@ class ReferenceWriter(object):
             volume = self.data.get("publication", {}).get("volumeNum", "").rjust(4, "0")
             output_dir = self.basedir + bibstem + "/" + volume
             self.output_file = output_dir + "/" + self.bibcode + "." + file_ext
+            self.output_file = self.output_file.replace("&", "+")
 
         except Exception as err:
             pass


### PR DESCRIPTION
- deals with the case where first_page is "NP"
- creates *NIX friendly pathnames for reference files of ampersand bibstems (`& -> +`)
- prep work for using ISBN to get bibstem from journalsdb