### PR TITLE
Updates adsenrich.references to use the DOI in place of bibcode for crossref references

### DIFF
--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -7,7 +7,7 @@ from adsenrich.data import *
 from adsenrich.exceptions import *
 from adsenrich.utils import issn2info
 
-proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), " ../"))
+proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), "../"))
 conf = load_config(proj_home=proj_home)
 
 

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -143,6 +143,8 @@ class ReferenceWriter(object):
                     if p.get("DOI", None):
                         doi = p.get("DOI")
                         doi = doi.replace("/", "_")
+                        bibstem = self.bibcode[4:9].rstrip(".")
+                        volume = self.data.get("publication", {}).get("volumeNum", "").rjust(4, "0")
                         output_dir = self.basedir + bibstem + "/" + volume
                         self.output_file = output_dir + "/" + doi + ".cr.xml"
             else:

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -13,7 +13,9 @@ conf = load_config(proj_home=proj_home)
 
 def de_dash_entity(input_string):
     output_string = input_string
-    dash_entities = ["&mdash;", "&ndash;", "&hyphen;", "&minus;", "&dash;", "&horbar;", "&x2012;"]
+    dash_entities = ["&mdash;", "&ndash;", "&hyphen;", "&minus;", "&dash;", "&horbar;", "&x2010;", "&x2011;", "&x2012;", "&x2013;", "&x2014;", "&#8208;", "&#8209;", "&#8210;", "&#8211;", "&#8212;"]
+    unicode_entities = [html.unescape(x) for x in dash_entities]
+    dash_entities.extend(unicode_entities)
     for d in dash_entities:
         output_string = output_string.replace(d, "-")
     return output_string

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -7,7 +7,7 @@ from adsenrich.data import *
 from adsenrich.exceptions import *
 from adsenrich.utils import issn2info
 
-proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), "../"))
+proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), " ../"))
 conf = load_config(proj_home=proj_home)
 
 
@@ -136,7 +136,16 @@ class ReferenceWriter(object):
             self._extract_refs_from_record()
             if not self.reference_list:
                 raise NoReferencesException("There are no references in this record.")
-            self._create_output_file_name()
+            if self.reference_source == "cr":
+                pids = self.data.get("persistentIDs", [])
+                doi = "no_doi_found"
+                for p in pids:
+                    if p.get("DOI", None):
+                        doi = p.get("DOI")
+                        doi = doi.replace("/", "_")
+                        self.output_file = doi + ".cr.xml"
+            else:
+                self._create_output_file_name()
 
             if not self.output_file:
                 raise NoOutFileException("Missing output file name.")

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -157,7 +157,7 @@ class ReferenceWriter(object):
                         bibstem = self.bibcode[4:9].rstrip(".")
                         volume = self.data.get("publication", {}).get("volumeNum", "").rjust(4, "0")
                         output_dir = self.basedir + bibstem + "/" + volume
-                        self.output_file = output_dir + "/" + newdoi + ".cr.xml"
+                        self.output_file = output_dir + "/" + newdoi + ".xref.xml"
             else:
                 self._create_output_file_name()
 

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -1,3 +1,4 @@
+import html
 import os
 
 from adsputils import load_config
@@ -9,6 +10,13 @@ from adsenrich.utils import issn2info
 
 proj_home = os.path.realpath(os.path.join(os.path.dirname(__file__), "../"))
 conf = load_config(proj_home=proj_home)
+
+def de_dash_entity(input_string):
+    output_string = input_string
+    dash_entities = ["&mdash;", "&ndash;", "&hyphen;", "&minus;", "&dash;", "&horbar;", "&x2012;"]
+    for d in dash_entities:
+        output_string = output_string.replace(d, "-")
+    return output_string
 
 
 class ReferenceWriter(object):
@@ -143,10 +151,11 @@ class ReferenceWriter(object):
                     if p.get("DOI", None):
                         doi = p.get("DOI")
                         doi = doi.replace("/", "_")
+                        newdoi = de_dash_entity(doi)
                         bibstem = self.bibcode[4:9].rstrip(".")
                         volume = self.data.get("publication", {}).get("volumeNum", "").rjust(4, "0")
                         output_dir = self.basedir + bibstem + "/" + volume
-                        self.output_file = output_dir + "/" + doi + ".cr.xml"
+                        self.output_file = output_dir + "/" + newdoi + ".cr.xml"
             else:
                 self._create_output_file_name()
 

--- a/adsenrich/references.py
+++ b/adsenrich/references.py
@@ -143,7 +143,8 @@ class ReferenceWriter(object):
                     if p.get("DOI", None):
                         doi = p.get("DOI")
                         doi = doi.replace("/", "_")
-                        self.output_file = doi + ".cr.xml"
+                        output_dir = self.basedir + bibstem + "/" + volume
+                        self.output_file = output_dir + "/" + doi + ".cr.xml"
             else:
                 self._create_output_file_name()
 


### PR DESCRIPTION
- modifies crossref reference handling to use the doi in place of the bibcode in the output filename
- converts dash-related entities and unicode to ascii `-` in the filename 